### PR TITLE
Performance Enhancements (mostly nested)

### DIFF
--- a/lib/http_api_tools/base_json_serializer.rb
+++ b/lib/http_api_tools/base_json_serializer.rb
@@ -10,11 +10,11 @@ module HttpApiTools
 
     attr_reader :serializable, :relation_includes, :result, :meta_data
 
-    def initialize(serializable, attrs = {})
-      @serializable = serializable
-      @relation_includes = attrs[:relation_includes] || RelationIncludes.new
-      @result = attrs[:result] || {}
-      @meta_data = { type: root_type, root_key: root_key.to_s }
+    def initialize(serializable, attrs = nil)
+      @serializable      = serializable
+      @relation_includes = (attrs && attrs[:relation_includes]) || RelationIncludes.new
+      @result            = (attrs && attrs[:result]) || {}
+      @meta_data         = { type: root_type, root_key: root_key.to_s }
     end
 
 
@@ -82,11 +82,11 @@ module HttpApiTools
     protected
 
     def root_key
-      @@_root_key ||= self.class._serializes.name.split("::").last.underscore.pluralize.to_sym
+      @@_root_key ||= self.class._serializes.name.split("::").last.underscore.pluralize.freeze.to_sym
     end
 
     def root_type
-      @@_root_type ||= root_key.to_s.singularize
+      @@_root_type ||= root_key.to_s.singularize.freeze
     end
 
     attr_accessor :identity_map
@@ -101,7 +101,7 @@ module HttpApiTools
       {
         includable: includable.to_s.blank? ? '*' : includable.to_s,
         included: relation_includes.to_s
-      }
+      }.freeze
     end
 
     def serializer_group

--- a/lib/http_api_tools/base_json_serializer.rb
+++ b/lib/http_api_tools/base_json_serializer.rb
@@ -1,4 +1,3 @@
-
 require "active_support/core_ext/class/attribute"
 require "active_support/json"
 require 'active_support/core_ext/string/inflections'
@@ -15,7 +14,7 @@ module HttpApiTools
       @serializable = serializable
       @relation_includes = attrs[:relation_includes] || RelationIncludes.new
       @result = attrs[:result] || {}
-      @meta_data = { type: root_key.to_s.singularize, root_key: root_key.to_s }
+      @meta_data = { type: root_type, root_key: root_key.to_s }
     end
 
 
@@ -82,6 +81,14 @@ module HttpApiTools
 
     protected
 
+    def root_key
+      @@_root_key ||= self.class._serializes.name.split("::").last.underscore.pluralize.to_sym
+    end
+
+    def root_type
+      @@_root_type ||= root_key.to_s.singularize
+    end
+
     attr_accessor :identity_map
 
     private
@@ -89,10 +96,6 @@ module HttpApiTools
     attr_writer :relation_includes
     attr_reader :type_key_resolver
     attr_accessor :serializer_map, :meta_data
-
-    def root_key
-      @_root_key ||= self.class._serializes.name.split("::").last.underscore.pluralize.to_sym
-    end
 
     def includes_meta_data
       {

--- a/lib/http_api_tools/model/attributes.rb
+++ b/lib/http_api_tools/model/attributes.rb
@@ -39,7 +39,7 @@ module HttpApiTools
       end
 
       def has_many_changed(has_many_name)
-        send("#{has_many_name.to_s.singularize}_ids=".freeze, Array(send(has_many_name)).map(&:id).compact)
+        send(ActiveSupport::Inflector.singularize(has_many_name) + "_ids=".freeze, Array(send(has_many_name)).map(&:id).compact)
       end
 
       private
@@ -164,7 +164,8 @@ module HttpApiTools
 
           self._has_many_relations[attr_name] = options
 
-          ids_attr_name = "#{attr_name.to_s.singularize}_ids"
+
+          ids_attr_name = ActiveSupport::Inflector.singularize(attr_name) + "_ids"
           id_setter_method_name = "#{ids_attr_name}="
 
           send(:attr_reader, attr_name)

--- a/lib/http_api_tools/model/attributes.rb
+++ b/lib/http_api_tools/model/attributes.rb
@@ -26,8 +26,8 @@ module HttpApiTools
           value = attrs[attr_name]
           value = attrs[attr_name.to_s.freeze] if value.nil? && !self._with_indifferent_access
 
-          raw_value = value == nil ? default_for(attr_options) : value
-          set_raw_value(attr_name, attr_options, raw_value, true) unless raw_value == nil
+          raw_value = value.nil? ? default_for(attr_options) : value
+          set_raw_value(attr_name, attr_options, raw_value, true) unless raw_value.nil?
         end
 
         self.errors = attrs[:errors] || {}

--- a/lib/http_api_tools/model/attributes.rb
+++ b/lib/http_api_tools/model/attributes.rb
@@ -20,7 +20,7 @@ module HttpApiTools
 
       def initialize(attrs = {})
 
-        attrs = attrs.with_indifferent_access
+        attrs = attrs.with_indifferent_access if self._with_indifferent_access
 
         attributes.each do |attr_name, attr_options|
           raw_value = attrs[attr_name] == nil ? default_for(attr_options) : attrs[attr_name]
@@ -111,6 +111,9 @@ module HttpApiTools
 
         base.extend(ClassMethods)
         base.send(:attr_accessor, :errors)
+
+        base.class_attribute :_with_indifferent_access
+        base._with_indifferent_access = false
       end
 
       module ClassMethods
@@ -155,7 +158,6 @@ module HttpApiTools
           end
         end
 
-
         def has_many(attr_name, options = {})
 
           self._has_many_relations[attr_name] = options
@@ -174,6 +176,10 @@ module HttpApiTools
             instance_variable_set("@#{ids_attr_name}", value)
           end
 
+        end
+
+        def with_indifferent_access(value)
+          self._with_indifferent_access = value
         end
 
       end

--- a/lib/http_api_tools/model/attributes.rb
+++ b/lib/http_api_tools/model/attributes.rb
@@ -27,7 +27,7 @@ module HttpApiTools
           value = attrs[attr_name.to_s.freeze] if value.nil? && !self._with_indifferent_access
 
           raw_value = value == nil ? default_for(attr_options) : value
-          set_raw_value(attr_name, raw_value, true) unless raw_value == nil
+          set_raw_value(attr_name, attr_options, raw_value, true) unless raw_value == nil
         end
 
         self.errors = attrs[:errors] || {}
@@ -39,20 +39,19 @@ module HttpApiTools
       end
 
       def has_many_changed(has_many_name)
-        send("#{has_many_name.to_s.singularize}_ids=", Array(send(has_many_name)).map(&:id).compact)
+        send("#{has_many_name.to_s.singularize}_ids=".freeze, Array(send(has_many_name)).map(&:id).compact)
       end
 
       private
 
-      def set_raw_value(attr_name, raw_value, apply_if_read_only = false)
+      def set_raw_value(attr_name, attr_def, raw_value, apply_if_read_only = false)
 
-        attr_def = attributes[attr_name]
         value = transformed_value(attr_def[:type], raw_value)
 
         if attr_def[:read_only] && apply_if_read_only
-          instance_variable_set("@#{attr_name}", value)
+          instance_variable_set("@#{attr_name}".freeze, value)
         elsif
-          self.send("#{attr_name}=", value)
+          self.send("#{attr_name}=".freeze, value)
         end
       end
 
@@ -91,12 +90,12 @@ module HttpApiTools
       end
 
       def set_belongs_to_value(attr_name, value)
-        instance_variable_set("@#{attr_name}", value)
-        send("#{attr_name}_id=", value.try(:id))
+        instance_variable_set("@#{attr_name}".freeze, value)
+        send("#{attr_name}_id=".freeze, value.try(:id))
       end
 
       def set_has_many_value(attr_name, value)
-        instance_variable_set("@#{attr_name}", HasManyArray.new(value, self, attr_name))
+        instance_variable_set("@#{attr_name}".freeze, HasManyArray.new(value, self, attr_name))
         has_many_changed(attr_name)
       end
 

--- a/lib/http_api_tools/model/attributes.rb
+++ b/lib/http_api_tools/model/attributes.rb
@@ -23,7 +23,10 @@ module HttpApiTools
         attrs = attrs.with_indifferent_access if self._with_indifferent_access
 
         attributes.each do |attr_name, attr_options|
-          raw_value = attrs[attr_name] == nil ? default_for(attr_options) : attrs[attr_name]
+          value = attrs[attr_name]
+          value = attrs[attr_name.to_s.freeze] if value.nil? && !self._with_indifferent_access
+
+          raw_value = value == nil ? default_for(attr_options) : value
           set_raw_value(attr_name, raw_value, true) unless raw_value == nil
         end
 

--- a/spec/http_api_tools/support/spec_models_for_serializing.rb
+++ b/spec/http_api_tools/support/spec_models_for_serializing.rb
@@ -46,6 +46,8 @@ class Company
   belongs_to :parent_company
   belongs_to :address
 
+  with_indifferent_access(true)
+
 
   #Act like active record for reflectively interogating type info
   def self.reflections


### PR DESCRIPTION
## [Master](https://buildkite.com/hooroo/hat-dot-gem/builds/11)
### [JRuby](https://buildkite.com/hooroo/hat-dot-gem/builds/11#6e212d98-0657-4c48-9fcd-ea68813d6ed3/95-136)
```
HttpApiTools::Nesting::JsonSerializer
nested-models: 17854.0 ms
nested-serializes: 42975.0 ms
nested-json: 881.0 ms
 
HttpApiTools::Sideloading::JsonSerializer
sideloaded-models: 16685.0 ms
sideloaded-serializes: 111.0 ms
sideloaded-json: 5.0 ms
```

### [MRI](https://buildkite.com/hooroo/hat-dot-gem/builds/11#9847ad6b-83bc-4934-911a-2451de52566f/95-100)
```
HttpApiTools::Nesting::JsonSerializer
nested-models: 31110.592909000003 ms
nested-serializes: 66908.016696 ms
nested-json: 2273.230271 ms
 
HttpApiTools::Sideloading::JsonSerializer
sideloaded-models: 33484.473164 ms
sideloaded-serializes: 167.360278 ms
sideloaded-json: 5.7206790000000005 ms
```

## [bili_perf](https://buildkite.com/hooroo/hat-dot-gem/builds?branch=bili_perf)
### [JRuby](https://buildkite.com/hooroo/hat-dot-gem/builds/17#c8f55aab-aca5-445c-83c3-0b1f23963311/97-138)
```
HttpApiTools::Nesting::JsonSerializer
nested-models: 4280.0 ms
nested-serializes: 8417.0 ms
nested-json: 727.0 ms
 
HttpApiTools::Sideloading::JsonSerializer
sideloaded-models: 3519.0 ms
sideloaded-serializes: 104.0 ms
sideloaded-json: 5.0 ms
```

### [MRI](https://buildkite.com/hooroo/hat-dot-gem/builds/17#59fe45ad-9a6a-4596-a86b-e1c55cc99f5b/97-102)
```
HttpApiTools::Nesting::JsonSerializer
nested-models: 9625.82165 ms
nested-serializes: 24572.071655 ms
nested-json: 2480.702499 ms
 
HttpApiTools::Sideloading::JsonSerializer
sideloaded-models: 10332.308903 ms
sideloaded-serializes: 110.826937 ms
sideloaded-json: 5.725747 ms
```


Some of the biggest wins were:
* Defining the root key at a class level (plurualize and singularize at an instance level was performing many regex)
* Remove `with_indifferent_access`
* BigDecimal == nil is much slower than BigDecimal.nil?


## Nested Performance Increase
JRuby Model Creation: 4x
JRuby Model Serialization: 5x

MRI Model Creation: 3x
MRI Model Serialization: 2x
