### PR TITLE
Nil namespace bug

### DIFF
--- a/lib/http_api_tools/sideloading/json_deserializer.rb
+++ b/lib/http_api_tools/sideloading/json_deserializer.rb
@@ -17,7 +17,7 @@ module HttpApiTools
         @identity_map = IdentityMap.new
         @sideload_map = SideloadMap.new(json, root_key)
         @key_to_class_mappings = {}
-        @namespace = opts[:namespace]
+        @namespace = opts[:namespace] || NullNamespace.new
       end
 
       def deserialize
@@ -136,6 +136,11 @@ module HttpApiTools
         nil
       end
 
+      class NullNamespace
+        def name
+          nil
+        end
+      end
 
     end
   end

--- a/spec/http_api_tools/sideloading/json_deserializer_spec.rb
+++ b/spec/http_api_tools/sideloading/json_deserializer_spec.rb
@@ -43,8 +43,9 @@ module HttpApiTools
 
       end
 
+      let(:namespace) { ForDeserializing }
       let(:company) do
-        JsonDeserializer.new(json, namespace: ForDeserializing ).deserialize.first
+        JsonDeserializer.new(json, namespace: namespace).deserialize.first
       end
 
       describe "basic deserialization" do
@@ -91,6 +92,35 @@ module HttpApiTools
           expect(company.parent_company_id).to eql 40
         end
 
+      end
+
+      context 'when namespace is nil' do
+        let(:namespace) { nil }
+        let(:json) do
+          {
+            'meta' => {
+              'type' => 'company',
+              'root_key' => 'companies'
+            },
+            'companies' => [{
+              'id' => 2,
+              'name' => "Hooroo",
+              'brand' => "We are travellers or something"
+            }],
+            'linked' => {}
+          }
+        end
+
+        describe 'basic deserialization' do
+          before do
+            klass = Class.new(ForDeserializing::Company)
+            Object.const_set "Company", klass
+          end
+
+          it "creates model from the root object" do
+            expect(company.id).to eq json['companies'][0]['id']
+          end
+        end
       end
     end
   end

--- a/spec/http_api_tools/sideloading/json_deserializer_spec.rb
+++ b/spec/http_api_tools/sideloading/json_deserializer_spec.rb
@@ -43,9 +43,8 @@ module HttpApiTools
 
       end
 
-      let(:namespace) { ForDeserializing }
       let(:company) do
-        JsonDeserializer.new(json, namespace: namespace).deserialize.first
+        JsonDeserializer.new(json, namespace: ForDeserializing).deserialize.first
       end
 
       describe "basic deserialization" do

--- a/spec/http_api_tools/sideloading/json_deserializer_spec.rb
+++ b/spec/http_api_tools/sideloading/json_deserializer_spec.rb
@@ -96,33 +96,29 @@ module HttpApiTools
 
       context 'when namespace is nil' do
         let(:namespace) { nil }
+        let(:coffee_name) { "Flavour Country" }
         let(:json) do
           {
             'meta' => {
-              'type' => 'company',
-              'root_key' => 'companies'
+              'type' => 'coffee',
+              'root_key' => 'coffees'
             },
-            'companies' => [{
+            'coffees' => [{
               'id' => 2,
-              'name' => "Hooroo",
-              'brand' => "We are travellers or something"
+              'name' => coffee_name
             }],
             'linked' => {}
           }
         end
 
+        let(:coffee) do
+          JsonDeserializer.new(json).deserialize.first
+        end
+
         describe 'basic deserialization' do
-          before do
-            klass = Class.new(ForDeserializing::Company)
-            Object.const_set "Company", klass
-          end
-
-          after do
-            Object.send(:remove_const, :Company)
-          end
-
           it "creates model from the root object" do
-            expect(company.id).to eq json['companies'][0]['id']
+            expect(coffee.id).to eq json['coffees'][0]['id']
+            expect(coffee.name).to eq coffee_name
           end
         end
       end

--- a/spec/http_api_tools/sideloading/json_deserializer_spec.rb
+++ b/spec/http_api_tools/sideloading/json_deserializer_spec.rb
@@ -117,6 +117,10 @@ module HttpApiTools
             Object.const_set "Company", klass
           end
 
+          after do
+            Object.send(:remove_const, :Company)
+          end
+
           it "creates model from the root object" do
             expect(company.id).to eq json['companies'][0]['id']
           end

--- a/spec/http_api_tools/support/spec_models_for_deserializing.rb
+++ b/spec/http_api_tools/support/spec_models_for_deserializing.rb
@@ -3,6 +3,13 @@
 require 'http_api_tools/model'
 require 'ostruct'
 
+class Coffee
+  include HttpApiTools::Model::Attributes
+
+  attribute :id
+  attribute :name
+end
+
 module ForDeserializing
   class Person
 


### PR DESCRIPTION
Namespace in the Deserializer default to nil.

Namespace is later called with `#name`, this blows up silently.

Default to a NullObject for Namespace if it is nil.