### PR TITLE
By default the serializer now uses as_json instead of to_s

### DIFF
--- a/docker-compose.yml.template
+++ b/docker-compose.yml.template
@@ -1,5 +1,5 @@
 app:
-  image: docker-registry.in.jqdev.net/hooroo-base-${RUBY_VERSION}:stable
+  image: 730011650125.dkr.ecr.ap-southeast-2.amazonaws.com/hooroo-base-${RUBY_VERSION}:stable
   environment:
     TZ: Australia/Melbourne
     LANG: en_US.UTF-8

--- a/docker-compose.yml.template
+++ b/docker-compose.yml.template
@@ -5,7 +5,7 @@ app:
     LANG: en_US.UTF-8
     LC_ALL: en_US.UTF-8
     LC_CTYPE: en_US.UTF-8
-    HEADLESS: true
+    HEADLESS: "true"
     DOCKER_HOST:
     BUILDBOX_COMMIT:
     BUILD_FARM_RUN:

--- a/docker-compose.yml.template
+++ b/docker-compose.yml.template
@@ -1,5 +1,5 @@
 app:
-  image: docker-registry.in.jqdev.net/hooroo-base-${RUBY_VERSION}:531
+  image: docker-registry.in.jqdev.net/hooroo-base-${RUBY_VERSION}:stable
   environment:
     TZ: Australia/Melbourne
     LANG: en_US.UTF-8

--- a/lib/http_api_tools/base_json_serializer.rb
+++ b/lib/http_api_tools/base_json_serializer.rb
@@ -28,7 +28,7 @@ module HttpApiTools
           if self.respond_to?(attr_name)
             attribute_hash[attr_name] = self.send(attr_name)
           else
-            attribute_hash[attr_name] = serializable.send(attr_name)
+            attribute_hash[attr_name] = serializable.send(attr_name).as_json
           end
         end
       end

--- a/spec/http_api_tools/sideloading/json_serializer_spec.rb
+++ b/spec/http_api_tools/sideloading/json_serializer_spec.rb
@@ -10,7 +10,7 @@ module HttpApiTools
 
       let(:company) { Company.new(id: 1, name: 'Hooroo', phone: '555010101') }
       let(:previous_company) { Company.new(id: 2, name: 'Not Hooroo', phone: '555010102') }
-      let(:person) { Person.new(id: 2, first_name: 'Rob', last_name: 'Monie', dob: '1976-01-01', email: 'rob@example.com', tax_file_number: '123456789', something_personal: 'shhhh', something_public: 'hello') }
+      let(:person) { Person.new(id: 2, first_name: 'Rob', last_name: 'Monie', dob: '1976-01-01', email: 'rob@example.com', tax_file_number: '123456789', something_personal: 'shhhh', something_public: 'hello', created_at: Time.now) }
       let(:skill) { Skill.new(id: 3, name: "JSON Serialization", descripton: 'description') }
       let(:skill2) { Skill.new(id: 4, name: "JSON Serialization 2", descripton: 'description') }
       let(:hidden_talent) { Skill.new(id: 5, name: "XRay Vision") }
@@ -34,17 +34,28 @@ module HttpApiTools
             let(:serialized) { PersonSerializer.new(person).as_json.with_indifferent_access }
             let(:serialized_person) { serialized[:people].first }
 
-            it "serializes basic attributes" do
-              expect(serialized_person[:id]).to eql person.id
-              expect(serialized_person[:first_name]).to eql person.first_name
-              expect(serialized_person[:last_name]).to eql person.last_name
+
+            describe 'basic attributes' do
+              context 'that are json primatives' do
+                it "serializes them" do
+                  expect(serialized_person[:id]).to eql person.id
+                  expect(serialized_person[:first_name]).to eql person.first_name
+                  expect(serialized_person[:last_name]).to eql person.last_name
+                end
+              end
+
+              context 'that are non json primatives' do
+                it 'calls that objects as_json to serialize it' do
+                  expect(serialized_person[:created_at]).to eql(person.created_at.as_json)
+                end
+              end
             end
 
             it 'expect basic attributes with no value' do
               expect(serialized_person).to have_key(:dob)
             end
-
-            it "serializes attributes defined as methods on the serializer" do
+          
+            it "serializes attributes defined as methods on the serialize" do
               expect(serialized_person[:full_name]).to eql "#{person.first_name} #{person.last_name}"
             end
 

--- a/spec/http_api_tools/support/spec_models_for_serializing.rb
+++ b/spec/http_api_tools/support/spec_models_for_serializing.rb
@@ -12,6 +12,7 @@ class Person
   attribute :first_name
   attribute :last_name
   attribute :dob
+  attribute :created_at
   attribute :email, exclude_when: :exclude_email?
   attribute :tax_file_number
   attribute :something_personal

--- a/spec/http_api_tools/support/spec_sideloading_serializers.rb
+++ b/spec/http_api_tools/support/spec_sideloading_serializers.rb
@@ -12,6 +12,7 @@ module HttpApiTools
       attribute :last_name
       attribute :full_name
       attribute :dob
+      attribute :created_at
 
       attribute :email, exclude_when: :exclude_email?
       attribute :tax_file_number, exclude_when: :exclude_tax_file_number?


### PR DESCRIPTION
In Rails 4 the default to_s on a DateTime is different to the default as_json